### PR TITLE
Only warn for device orientation in development

### DIFF
--- a/src/react-parallax-tilt/ReactParallaxTilt.tsx
+++ b/src/react-parallax-tilt/ReactParallaxTilt.tsx
@@ -72,7 +72,11 @@ class ReactParallaxTilt extends PureComponent<Props> {
   /* istanbul ignore next */
   private addDeviceOrientationEventListener = async () => {
     if (!window.DeviceOrientationEvent) {
-      console.error("Browser doesn't support Device Orientation.");
+      // runtime mode detection based on https://stackoverflow.com/a/35470995/7127932
+      if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+        // see https://github.com/mkosir/react-parallax-tilt/issues/11
+        console.warn("Browser doesn't support Device Orientation.");
+      }
       return;
     }
 

--- a/src/react-parallax-tilt/ReactParallaxTilt.tsx
+++ b/src/react-parallax-tilt/ReactParallaxTilt.tsx
@@ -72,9 +72,7 @@ class ReactParallaxTilt extends PureComponent<Props> {
   /* istanbul ignore next */
   private addDeviceOrientationEventListener = async () => {
     if (!window.DeviceOrientationEvent) {
-      // runtime mode detection based on https://stackoverflow.com/a/35470995/7127932
       if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-        // see https://github.com/mkosir/react-parallax-tilt/issues/11
         console.warn("Browser doesn't support Device Orientation.");
       }
       return;


### PR DESCRIPTION
Closes #11.

### 🚀 Pull Request Template

**Description**

Instead of logging an error in both dev and prod when gyroscope mode is enabled and the device orientation API isn't available, a warning is logged in development and nothing is logged in production. 

**Checklist**

- [ ] Lint, prettier and all tests passing (`npm run validate`)
    - this PR is untested and unlinted but the validate script *should* pass
- [ ] Extended the Storybook demo page / README / documentation, if necessary
    - n/a
