### PR TITLE
Fix/calculate glare size

### DIFF
--- a/src/features/glare/Glare.ts
+++ b/src/features/glare/Glare.ts
@@ -3,8 +3,6 @@ import { constrainToRange } from '../../common/utils';
 import { ElementSizePosition, ClientPosition } from '../../common/types';
 import { IStyle } from '../../common/IStyle';
 
-const GLARE_EL_SIZE_FACTOR = 2;
-
 export class Glare implements IStyle {
   public glareWrapperEl: HTMLDivElement;
   public glareEl: HTMLDivElement;
@@ -46,9 +44,11 @@ export class Glare implements IStyle {
   }
 
   private calculateGlareSize = (wrapperElSize: ElementSizePosition): GlareSize => {
+    const { width: w, height: h } = wrapperElSize;
+    const wrapperElDiagonal = Math.sqrt(w! ** 2 + h! ** 2);
     return {
-      width: wrapperElSize.width! * GLARE_EL_SIZE_FACTOR,
-      height: wrapperElSize.height! * GLARE_EL_SIZE_FACTOR,
+      width: wrapperElDiagonal,
+      height: wrapperElDiagonal,
     };
   };
 

--- a/test/glare.test.tsx
+++ b/test/glare.test.tsx
@@ -133,8 +133,10 @@ describe("Glare - angle/opacity - Callback 'onMove' should return correct calcul
     const wrapperElSize: ElementSizePosition = { width: 150, height: 100, left: 0, top: 0 };
     wrapper.instance()['glare'].setSize(wrapperElSize);
     const glareStyle = wrapper.instance()['glare'].glareEl.style;
-    expect(glareStyle.width).toEqual('300px');
-    expect(glareStyle.height).toEqual('200px');
+    const { width: w, height: h } = wrapperElSize;
+    const wrapperElDiagonal = Math.sqrt(w! ** 2 + h! ** 2);
+    expect(glareStyle.width).toEqual(`${wrapperElDiagonal}px`);
+    expect(glareStyle.height).toEqual(`${wrapperElDiagonal}px`);
   });
 
   it('Glare with flip vertically/horizontally', () => {


### PR DESCRIPTION
### 🚀 Pull Request

**Description**

**Bug Fix Proposal:** change how the glare element size is calculated.

Why:
1. Setting the glare size based on the wrapper element diagonal guarantees that the glare will cover the entire wrapper element.
2. Fixes Issue #16 

**Checklist**

- [x] Lint, prettier and all tests passing (`npm run validate`)
- [ ] Extended the Storybook demo page / README / documentation, if necessary
