### PR TITLE
feat: added glareBorderRadius prop to stop glare overlapping rounded children

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The maximum glare opacity (0.5 = 50%, 1 = 100%, etc.).
 **glareColor**: _string_ ▶︎ `#ffffff`  
 Set color of glare effect.
 
+**glareBorderRadius**: _string_ ▶︎ `0`  
+Accepts any standard CSS border radius.
+Useful if the glare color is different to the page color.
+
 **glarePosition**: _GlarePosition_ ▶︎ `bottom`  
 _GlarePosition = 'top' | 'right' | 'bottom' | 'left' | 'all'_  
 Set position of glare effect.

--- a/src/features/glare/Glare.ts
+++ b/src/features/glare/Glare.ts
@@ -24,6 +24,7 @@ export class Glare implements IStyle {
       width: '100%',
       height: '100%',
       overflow: 'hidden',
+      '-webkit-mask-image': '-webkit-radial-gradient(white, black)',
     };
 
     const glareSize = this.calculateGlareSize(wrapperElSize);
@@ -40,6 +41,11 @@ export class Glare implements IStyle {
     Object.assign(this.glareWrapperEl.style, styleGlareWrapper);
     Object.assign(this.glareEl.style, styleGlare);
   }
+
+  private getBorderRadius = (props: GlareProps): GlareProps['glareBorderRadius'] => {
+    const { glareBorderRadius } = props;
+    return glareBorderRadius;
+  };
 
   private calculateGlareSize = (wrapperElSize: ElementSizePosition): GlareSize => {
     const { width: w, height: h } = wrapperElSize;
@@ -117,6 +123,7 @@ export class Glare implements IStyle {
 
   public render = (props: GlareProps): void => {
     const { glareColor } = props;
+    this.glareWrapperEl.style.borderRadius = this.getBorderRadius(props);
     this.glareEl.style.transform = `rotate(${this.glareAngle}deg) translate(-50%, -50%)`;
     this.glareEl.style.opacity = this.glareOpacity.toString();
 

--- a/src/features/glare/types.ts
+++ b/src/features/glare/types.ts
@@ -19,6 +19,10 @@ export type GlareProps = {
    * Reverse the glare direction.
    */
   glareReverse?: boolean;
+  /**
+   * Set the border radius of the glare.
+   */
+  glareBorderRadius: string;
 };
 
 export type GlarePosition = 'top' | 'right' | 'bottom' | 'left' | 'all';

--- a/src/react-parallax-tilt/defaultProps.ts
+++ b/src/react-parallax-tilt/defaultProps.ts
@@ -9,6 +9,7 @@ const defaultGlareProps: GlareProps = {
   glareColor: '#ffffff',
   glarePosition: 'bottom',
   glareReverse: false,
+  glareBorderRadius: '0',
 };
 
 const defaultTiltProps: TiltProps = {


### PR DESCRIPTION
**Description**
Adds a new prop (glareBorderRadius) to handle an issue where glare corners were visible when the background color of the app and the glare color were different, if the child component had rounded edges.

fix #27

**Checklist**

- [x] Commit messages should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention as much as possible. After staging your changes please run `npm run commit`
- [x] Lint, prettier and all tests passing - `npm run validate`
- [x] Extended the Storybook demo page / README / documentation, if necessary
