### PR TITLE
Fixing missing source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "typings": "./dist/types/index.d.ts",
   "files": [
     "dist",
+    "src",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
Does not compile without missing /src folder

### 🚀 Pull Request Template

**Description**

Does not compile without warnings of missing /src files:

WARNING in ./node_modules/react-parallax-tilt/dist/index.esm.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '<project dir>/node_modules/react-parallax-tilt/src/common/utils.ts' file: Error: ENOENT: no such file or directory, open '<project dir>/node_modules/react-parallax-tilt/src/common/utils.ts'

**Checklist**

- [ ] Commit messages should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) as much as possible. After staging your changes please run `npm run commit`
- [ ] Lint, prettier and all tests passing - `npm run validate`
- [ ] Extended the Storybook demo page / README / documentation, if necessary
